### PR TITLE
tram-one scope (v2.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ninlil
+# rbel
 
 Fork of [rbel](https://github.com/aaaristo/rbel)
 
@@ -8,8 +8,8 @@ use custom elements in tagged template literals
 
 ```js
 const domBuilder = require('hyperx')
-const h = require('belit');
-const html = require('ninlil')(domBuilder, h, {
+const h = require('nanohtml');
+const html = require('rbel')(domBuilder, h, {
     row: (attrs, children) => html`
         <div class="row">
            ${children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ninlil",
-  "version": "1.0.2",
+  "name": "@tram-one/rbel",
+  "version": "2.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ninlil",
-  "version": "2.0.0",
+  "name": "@tram-one/rbel",
+  "version": "2.0.1",
   "description": "use custom elements in tagged template literals",
   "main": "index.js",
   "license": "BSD"


### PR DESCRIPTION
## Summary
Change name back to rbel, scoped under tram-one org.

## Checklist
- [x] PR Summary
- [ ] Tests
- [x] Version Bump
